### PR TITLE
Gdtot improvements

### DIFF
--- a/bot/helper/mirror_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_utils/download_utils/direct_link_generator.py
@@ -26,6 +26,7 @@ from base64 import standard_b64encode
 
 from bot import LOGGER, UPTOBOX_TOKEN, PHPSESSID, CRYPT
 from bot.helper.telegram_helper.bot_commands import BotCommands
+from bot.helper.ext_utils.bot_utils import is_gdtot_link
 from bot.helper.ext_utils.exceptions import DirectDownloadLinkException
 
 cookies = {"PHPSESSID": PHPSESSID, "crypt": CRYPT}
@@ -97,7 +98,7 @@ def direct_link_generator(link: str):
         return solidfiles(link)
     elif 'krakenfiles.com' in link:
         return krakenfiles(link)
-    elif 'new.gdtot.top' in link:
+    elif is_gdtot_link(link):
         return gdtot(link)
     else:
         raise DirectDownloadLinkException(f'No Direct link function found for {link}')
@@ -466,5 +467,5 @@ def gdtot(url: str) -> str:
         raise DirectDownloadLinkException(f"ERROR: {status}")
     else:
         gdlink = s3.find('a', class_="btn btn-outline-light btn-user font-weight-bold").get('href')
-        return gdlink 
+        return gdlink
 

--- a/bot/helper/mirror_utils/upload_utils/gdriveTools.py
+++ b/bot/helper/mirror_utils/upload_utils/gdriveTools.py
@@ -119,19 +119,26 @@ class GoogleDriveHelper:
     def deletefile(self, link: str):
         try:
             file_id = self.getIdFromUrl(link)
-        except (KeyError,IndexError):
+        except (KeyError, IndexError):
             msg = "Google Drive ID could not be found in the provided link"
             return msg
         msg = ''
         try:
             res = self.__service.files().delete(fileId=file_id, supportsTeamDrives=IS_TEAM_DRIVE).execute()
             msg = "Successfully deleted"
+            LOGGER.info(f"Delete Result: {msg}")
         except HttpError as err:
-            LOGGER.error(str(err))
             if "File not found" in str(err):
                 msg = "No such file exist"
+            elif "insufficientFilePermissions" in str(err):
+                msg = "Insufficient File Permissions"
+                token_service = self.alt_authorize()
+                if token_service is not None:
+                    self.__service = token_service
+                    return self.deletefile(link)
             else:
-                msg = "Something went wrong check log"
+                msg = str(err)
+            LOGGER.error(f"Delete Result: {msg}")
         finally:
             return msg
 
@@ -267,8 +274,7 @@ class GoogleDriveHelper:
                 link = f"https://drive.google.com/folderview?id={dir_id}"
                 if self.is_cancelled:
                     LOGGER.info("Deleting uploaded data from Drive...")
-                    msg = self.deletefile(link)
-                    LOGGER.info(f"{msg}")
+                    self.deletefile(link)
                     return
                 LOGGER.info("Uploaded To G-Drive: " + file_name)
             except Exception as e:
@@ -371,8 +377,7 @@ class GoogleDriveHelper:
                 durl = self.__G_DRIVE_DIR_BASE_DOWNLOAD_URL.format(dir_id)
                 if self.is_cancelled:
                     LOGGER.info("Deleting cloned data from Drive...")
-                    msg = self.deletefile(durl)
-                    LOGGER.info(f"{msg}")
+                    self.deletefile(durl)
                     return "your clone has been stopped and cloned data has been deleted!", "cancelled"
                 msg += f'<b>Name: </b><code>{meta.get("name")}</code>\n\n<b>Size: </b>{get_readable_file_size(self.transferred_size)}'
                 msg += '\n\n<b>Type: </b>Folder'

--- a/bot/modules/clone.py
+++ b/bot/modules/clone.py
@@ -21,7 +21,8 @@ def cloneNode(update, context):
         link = reply_to.text
     else:
         link = ''
-    if is_gdtot_link(link):
+    gdtot_link = is_gdtot_link(link)
+    if gdtot_link:
         try:
             link = gdtot(link)
         except DirectDownloadLinkException as e:
@@ -80,6 +81,8 @@ def cloneNode(update, context):
             sendMessage(men + result, context.bot, update)
         else:
             sendMarkup(result + cc, context.bot, update, button)
+        if gdtot_link:
+            gd.deletefile(link)
     else:
         sendMessage('Send Gdrive or gdtot link along with command or by replying to the link by command', context.bot, update)
 

--- a/bot/modules/count.py
+++ b/bot/modules/count.py
@@ -5,7 +5,9 @@ from bot.helper.mirror_utils.upload_utils.gdriveTools import GoogleDriveHelper
 from bot.helper.telegram_helper.message_utils import deleteMessage, sendMessage
 from bot.helper.telegram_helper.filters import CustomFilters
 from bot.helper.telegram_helper.bot_commands import BotCommands
-from bot.helper.ext_utils.bot_utils import is_gdrive_link
+from bot.helper.ext_utils.bot_utils import is_gdrive_link, is_gdtot_link
+from bot.helper.mirror_utils.download_utils.direct_link_generator import gdtot
+from bot.helper.ext_utils.exceptions import DirectDownloadLinkException
 
 
 def countNode(update, context):
@@ -17,6 +19,12 @@ def countNode(update, context):
         link = reply_to.text
     else:
         link = ''
+    gdtot_link = is_gdtot_link(link)
+    if gdtot_link:
+        try:
+            link = gdtot(link)
+        except DirectDownloadLinkException as e:
+            return sendMessage(str(e), context.bot, update)
     if is_gdrive_link(link):
         msg = sendMessage(f"Counting: <code>{link}</code>", context.bot, update)
         gd = GoogleDriveHelper()
@@ -29,6 +37,8 @@ def countNode(update, context):
         if uname is not None:
             cc = f'\n\n<b>cc: </b>{uname}'
         sendMessage(result + cc, context.bot, update)
+        if gdtot_link:
+            gd.deletefile(link)
     else:
         sendMessage('Send Gdrive link along with command or by replying to the link by command', context.bot, update)
 

--- a/bot/modules/delete.py
+++ b/bot/modules/delete.py
@@ -24,7 +24,6 @@ def deletefile(update, context):
         LOGGER.info(link)
         drive = gdriveTools.GoogleDriveHelper()
         msg = drive.deletefile(link)
-        LOGGER.info(f"Delete Result: {msg}")
     else:
         msg = 'Send Gdrive link along with command or by replying to the link by command'
     reply_message = sendMessage(msg, context.bot, update)

--- a/bot/modules/mirror.py
+++ b/bot/modules/mirror.py
@@ -407,6 +407,7 @@ def _mirror(bot, update, isZip=False, extract=False, isQbit=False, isLeech=False
             return
     elif not os.path.exists(link) and not bot_utils.is_mega_link(link) and not bot_utils.is_gdrive_link(link) and not bot_utils.is_magnet(link):
         try:
+            gdtot_link = bot_utils.is_gdtot_link(link)
             link = direct_link_generator(link)
         except DirectDownloadLinkException as e:
             LOGGER.info(e)
@@ -439,6 +440,8 @@ def _mirror(bot, update, isZip=False, extract=False, isQbit=False, isLeech=False
             download_dict[listener.uid] = download_status
         sendStatusMessage(update, bot)
         drive.download(link)
+        if gdtot_link:
+            drive.deletefile(link)
 
     elif bot_utils.is_mega_link(link):
         if BLOCK_MEGA_LINKS:


### PR DESCRIPTION
- Count gdtot links
- Delete first cloned file from drive or td
Note: if your main drive not full and using service accounts so first clone will be there and you should add your token.pickle for alt_authorize to delete the file from main drive but if main drive full and using service accounts so no need in this case

Signed-off-by: anasty17 <e.anastayyar@gmail.com>